### PR TITLE
fix(http-basic-auth-configuration) for Inform  http basic auth configuration

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -399,7 +399,7 @@ Config.define(
 # HTTP Basic Auth
 Config.define('HTTP_BASIC_AUTH_USER', None, 'HTTP Basic Auth Username')
 Config.define('HTTP_BASIC_AUTH_PASSWORD', None, 'HTTP Basic Auth Password')
-Config.define('HTTP_BASIC_AUTH_MODE', 'basic')
+Config.define('HTTP_BASIC_AUTH_MODE', 'basic', 'HTTP Basic Auth Mode, standard: basic')
 
 
 def generate_config():


### PR DESCRIPTION
## Tickets:

- [INFORM-1967](https://compuccino.atlassian.net/browse/INFORM-1967)

## Changes
- fix configuration definition for `HTTP_BASIC_AUTH_MODE` config option 

## Testing Instructions
- checkout code
- run `python setup.py install`
- run `thumbor`